### PR TITLE
Replace hard-coded version with assembly version

### DIFF
--- a/WindowsEdgeLight/MainWindow.xaml.cs
+++ b/WindowsEdgeLight/MainWindow.xaml.cs
@@ -90,7 +90,10 @@ public partial class MainWindow : Window
 
     private void ShowHelp()
     {
-        var helpMessage = @"Windows Edge Light - Keyboard Shortcuts
+        var version = System.Reflection.Assembly.GetExecutingAssembly()
+            .GetName().Version?.ToString() ?? "Unknown";
+        
+        var helpMessage = $@"Windows Edge Light - Keyboard Shortcuts
 
 💡 Toggle Light:  Ctrl + Shift + L
 🔆 Brightness Up:  Ctrl + Shift + ↑
@@ -102,7 +105,7 @@ public partial class MainWindow : Window
 • Right-click taskbar icon for menu
 
 Created by Scott Hanselman
-Version 0.6";
+Version {version}";
 
         System.Windows.MessageBox.Show(helpMessage, "Windows Edge Light - Help", 
             MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
The ShowHelp() method previously displayed a hard-coded version string ("0.6") in the help dialog. This approach required manual updates whenever the version changed, creating maintenance overhead and potential inconsistencies.

Now the version is dynamically retrieved from the assembly's version attribute using Reflection. This ensures the displayed version always matches the actual assembly version defined in the project file, eliminating the need for manual synchronization and reducing the risk of version mismatches in the UI.


Closes #3 