### PR TITLE
Punching a hole effect when the mouse hovers over the white border

### DIFF
--- a/WindowsEdgeLight/MainWindow.xaml
+++ b/WindowsEdgeLight/MainWindow.xaml
@@ -12,7 +12,6 @@
     Background="Transparent"
     KeyDown="Window_KeyDown"
     Loaded="Window_Loaded"
-    Unloaded="Window_Unloaded"
     ResizeMode="NoResize"
     ShowInTaskbar="True"
     Topmost="True"


### PR DESCRIPTION
Introduced a transparant `Canvas` with a `HoverCursorRing` overlay in `MainWindow.xaml` to display a visual cursor ring. Added a `DispatcherTimer` to monitor cursor position and dynamically punch a transparent hole in the frame geometry when the cursor hovers over the frame.

<img width="1021" height="418" alt="image" src="https://github.com/user-attachments/assets/dfd9acc9-599d-484c-be07-80bfbc6f9c9a" />
(Cursor is visible)

Key changes:
- Added `Unloaded` event handler for cleanup.
- Introduced `StartCursorMonitoring` and `CursorMonitorTimer_Tick` methods.
- Updated `CreateControlWindow` to store frame geometry and offsets.
- Enhanced `ToggleLight` to manage cursor ring visibility and geometry restoration.