### PR TITLE
Fix secondary monitor windows not handling DPI changes

### DIFF
--- a/WindowsEdgeLight/MainWindow.xaml.cs
+++ b/WindowsEdgeLight/MainWindow.xaml.cs
@@ -1147,6 +1147,19 @@ Version {version}";
             }
         };
 
+        window.DpiChanged += (s, dpiArgs) =>
+        {
+            ctx.DpiScaleX = dpiArgs.NewDpi.DpiScaleX;
+            ctx.DpiScaleY = dpiArgs.NewDpi.DpiScaleY;
+
+            window.Left = screen.WorkingArea.X / ctx.DpiScaleX;
+            window.Top = screen.WorkingArea.Y / ctx.DpiScaleY;
+            window.Width = screen.WorkingArea.Width / ctx.DpiScaleX;
+            window.Height = screen.WorkingArea.Height / ctx.DpiScaleY;
+
+            UpdateMonitorGeometry(ctx);
+        };
+
         return ctx;
     }
 


### PR DESCRIPTION
## Bug

Secondary monitor windows created by \CreateMonitorWindow\ (used in 'show on all monitors' mode) had no \DpiChanged\ event handler. This caused two problems when a monitor's DPI changed at runtime (e.g., docking/undocking a laptop):

1. **Incorrect window sizing/positioning** — the window dimensions were calculated at creation time using the initial DPI and never updated, so the edge light frame would be wrong-sized and mispositioned after a DPI change.
2. **Stale cursor hole-punch coordinates** — the cached \ctx.DpiScaleX\/\ctx.DpiScaleY\ values went stale, causing the cursor hole-punch geometry to use incorrect DPI scaling and appear at the wrong position.

## Fix

Added a \DpiChanged\ event handler to each secondary window in \CreateMonitorWindow\ that:
- Updates \ctx.DpiScaleX\ and \ctx.DpiScaleY\ from the new DPI values
- Repositions and resizes the window using \screen.WorkingArea\ divided by the new DPI scale
- Calls \UpdateMonitorGeometry(ctx)\ to rebuild the frame geometry

This mirrors the pattern already used in the main window's DPI handling logic.