### PR TITLE
[Repo Assist] Persist brightness, color temperature, and on/off state across restarts

### DIFF
--- a/WindowsEdgeLight/AppSettings.cs
+++ b/WindowsEdgeLight/AppSettings.cs
@@ -21,6 +21,22 @@ public class AppSettings
     public bool ExcludeFromCapture { get; set; } = true;
 
     /// <summary>
+    /// Whether the edge light is on or off (persisted across restarts)
+    /// </summary>
+    public bool IsLightOn { get; set; } = true;
+
+    /// <summary>
+    /// Brightness/opacity of the edge light, in the range [0.2, 1.0]
+    /// </summary>
+    public double Brightness { get; set; } = 1.0;
+
+    /// <summary>
+    /// Color temperature of the edge light, in the range [0.0, 1.0]
+    /// where 0.0 = coolest (blue-white) and 1.0 = warmest (amber)
+    /// </summary>
+    public double ColorTemperature { get; set; } = 0.5;
+
+    /// <summary>
     /// Load settings from disk
     /// </summary>
     public static AppSettings Load()

--- a/WindowsEdgeLight/MainWindow.xaml.cs
+++ b/WindowsEdgeLight/MainWindow.xaml.cs
@@ -156,6 +156,11 @@ public partial class MainWindow : Window
         // Load settings
         settings = AppSettings.Load();
         
+        // Restore persisted state
+        isLightOn = settings.IsLightOn;
+        currentOpacity = settings.Brightness;
+        _colorTemperature = settings.ColorTemperature;
+        
         SetupNotifyIcon();
     }
 
@@ -313,6 +318,16 @@ Version {version}";
 
         // Apply exclude from capture setting
         ApplyExcludeFromCapture();
+
+        // Apply persisted brightness and color temperature
+        EdgeLightBorder.Opacity = currentOpacity;
+        SetColorTemperature(_colorTemperature);
+
+        // Apply persisted on/off state
+        if (!isLightOn)
+        {
+            EdgeLightBorder.Visibility = Visibility.Collapsed;
+        }
 
         InstallMouseHook();
     }
@@ -673,6 +688,9 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        
+        settings.IsLightOn = isLightOn;
+        settings.Save();
     }
 
     public void HandleToggle()
@@ -776,6 +794,9 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        
+        settings.Brightness = currentOpacity;
+        settings.Save();
     }
 
     public void DecreaseBrightness()
@@ -785,6 +806,9 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        
+        settings.Brightness = currentOpacity;
+        settings.Save();
     }
 
     private void UpdateAdditionalMonitorWindows()
@@ -869,6 +893,9 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        
+        settings.ColorTemperature = _colorTemperature;
+        settings.Save();
     }
 
     public void MoveToNextMonitor()


### PR DESCRIPTION
Previously, only ExcludeFromCapture was saved to settings.json. Brightness, color temperature, and on/off state reset to defaults on every app restart.

Changes:
- AppSettings: add IsLightOn, Brightness, and ColorTemperature properties
- MainWindow: read persisted values after loading settings in constructor
- MainWindow: save settings after every brightness, color temp, or toggle change
- Window_Loaded: apply persisted opacity, color temperature, and visibility

No breaking changes - existing settings.json files gain the new fields with their default values (IsLightOn=true, Brightness=1.0, ColorTemperature=0.5).