### PR TITLE
Persist edge light state and notify hotkey conflicts

### DIFF
--- a/WindowsEdgeLight/AppSettings.cs
+++ b/WindowsEdgeLight/AppSettings.cs
@@ -21,6 +21,21 @@ public class AppSettings
     public bool ExcludeFromCapture { get; set; } = true;
 
     /// <summary>
+    /// Edge light brightness/opacity, in the range [0.2, 1.0].
+    /// </summary>
+    public double Brightness { get; set; } = 1.0;
+
+    /// <summary>
+    /// Color temperature blend in the range [0.0, 1.0], where 0 is coolest and 1 is warmest.
+    /// </summary>
+    public double ColorTemperature { get; set; } = 0.5;
+
+    /// <summary>
+    /// Whether the edge light is visible.
+    /// </summary>
+    public bool IsLightOn { get; set; } = true;
+
+    /// <summary>
     /// Load settings from disk
     /// </summary>
     public static AppSettings Load()

--- a/WindowsEdgeLight/MainWindow.xaml.cs
+++ b/WindowsEdgeLight/MainWindow.xaml.cs
@@ -155,6 +155,9 @@ public partial class MainWindow : Window
         
         // Load settings
         settings = AppSettings.Load();
+        currentOpacity = Math.Max(MinOpacity, Math.Min(MaxOpacity, settings.Brightness));
+        _colorTemperature = Math.Max(MinColorTemp, Math.Min(MaxColorTemp, settings.ColorTemperature));
+        isLightOn = settings.IsLightOn;
         
         SetupNotifyIcon();
     }
@@ -292,6 +295,7 @@ Version {version}";
     {
         SetupWindow();
         CreateFrameGeometry();
+        ApplyPersistedVisualSettings();
         CreateControlWindow();
         
         var hwnd = new WindowInteropHelper(this).Handle;
@@ -299,9 +303,7 @@ Version {version}";
         SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT | WS_EX_LAYERED);
         
         // Register global hotkeys
-        RegisterHotKey(hwnd, HOTKEY_TOGGLE, MOD_CONTROL | MOD_SHIFT, VK_L);
-        RegisterHotKey(hwnd, HOTKEY_BRIGHTNESS_UP, MOD_CONTROL | MOD_SHIFT, VK_UP);
-        RegisterHotKey(hwnd, HOTKEY_BRIGHTNESS_DOWN, MOD_CONTROL | MOD_SHIFT, VK_DOWN);
+        RegisterGlobalHotKeys(hwnd);
         
         // Hook into Windows message processing
         HwndSource source = HwndSource.FromHwnd(hwnd);
@@ -315,6 +317,44 @@ Version {version}";
         ApplyExcludeFromCapture();
 
         InstallMouseHook();
+    }
+
+    private void RegisterGlobalHotKeys(IntPtr hwnd)
+    {
+        var failedHotKeys = new List<string>();
+
+        if (!RegisterHotKey(hwnd, HOTKEY_TOGGLE, MOD_CONTROL | MOD_SHIFT, VK_L))
+        {
+            failedHotKeys.Add("Toggle Light (Ctrl+Shift+L)");
+        }
+
+        if (!RegisterHotKey(hwnd, HOTKEY_BRIGHTNESS_UP, MOD_CONTROL | MOD_SHIFT, VK_UP))
+        {
+            failedHotKeys.Add("Brightness Up (Ctrl+Shift+Up)");
+        }
+
+        if (!RegisterHotKey(hwnd, HOTKEY_BRIGHTNESS_DOWN, MOD_CONTROL | MOD_SHIFT, VK_DOWN))
+        {
+            failedHotKeys.Add("Brightness Down (Ctrl+Shift+Down)");
+        }
+
+        if (failedHotKeys.Count > 0)
+        {
+            notifyIcon?.ShowBalloonTip(
+                5000,
+                "Windows Edge Light hotkey conflict",
+                "Some keyboard shortcuts could not be registered because another app is using them:\n\n" +
+                string.Join("\n", failedHotKeys) +
+                "\n\nUse the tray menu controls instead.",
+                ToolTipIcon.Warning);
+        }
+    }
+
+    private void ApplyPersistedVisualSettings()
+    {
+        EdgeLightBorder.Opacity = currentOpacity;
+        EdgeLightBorder.Visibility = isLightOn ? Visibility.Visible : Visibility.Collapsed;
+        ApplyColorTemperature();
     }
 
     private void InstallMouseHook()
@@ -673,6 +713,8 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        settings.IsLightOn = isLightOn;
+        settings.Save();
     }
 
     public void HandleToggle()
@@ -776,6 +818,8 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        settings.Brightness = currentOpacity;
+        settings.Save();
     }
 
     public void DecreaseBrightness()
@@ -785,6 +829,8 @@ Version {version}";
         
         // Update all additional monitor windows
         UpdateAdditionalMonitorWindows();
+        settings.Brightness = currentOpacity;
+        settings.Save();
     }
 
     private void UpdateAdditionalMonitorWindows()
@@ -833,7 +879,13 @@ Version {version}";
     public void SetColorTemperature(double value)
     {
         _colorTemperature = Math.Max(MinColorTemp, Math.Min(MaxColorTemp, value));
+        ApplyColorTemperature();
+        settings.ColorTemperature = _colorTemperature;
+        settings.Save();
+    }
 
+    private void ApplyColorTemperature()
+    {
         // Map 0-1 slider to a simple cool-to-warm gradient.
         // We'll bias the inner gradient stops from blueish-white (cool) to amber (warm).
         // NOTE: This assumes the brush defined in XAML is still a LinearGradientBrush.


### PR DESCRIPTION
Windows Edge Light currently forgets brightness, color temperature, and on/off state after restart, and global hotkey conflicts fail silently. This preserves the user's last edge-light state across launches and makes shortcut registration failures visible instead of leaving users guessing.

The change extends the existing JSON settings model with brightness, color temperature, and light visibility, restores those values after frame geometry is created, and saves changes through the existing settings path when controls or hotkeys update state. Hotkey registration now checks each `RegisterHotKey` result and shows a tray balloon listing any shortcut that another app already owns, while keeping tray menu controls available as the fallback.

No new test project was added because the repository currently has no test project and separate AppSettings test proposals already exist. Existing restore/build/test commands were run successfully; `dotnet test` exits cleanly against the current solution, which has no test assemblies.

Fixes: #118