### PR TITLE
Add drag section so that users can drag control window.

### DIFF
--- a/WindowsEdgeLight/ControlWindow.xaml
+++ b/WindowsEdgeLight/ControlWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Controls"
-    Width="406"
+    Width="424"
     Height="48"
     AllowsTransparency="True"
     Background="Transparent"
@@ -30,6 +30,23 @@
         </Border.Style>
 
         <StackPanel Orientation="Horizontal">
+            <Border
+                x:Name="DragHandle"
+                Width="16"
+                Margin="4,4,0,4"
+                AutomationProperties.Name="Drag toolbar"
+                Cursor="SizeAll"
+                MouseLeftButtonDown="DragHandle_MouseLeftButtonDown"
+                ToolTip="Drag to move">
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    FontFamily="Segoe MDL2 Assets"
+                    FontSize="16"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="&#xE784;" />
+            </Border>
+
             <Button
                 x:Name="BrightnessDownButton"
                 Width="40"

--- a/WindowsEdgeLight/ControlWindow.xaml.cs
+++ b/WindowsEdgeLight/ControlWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Input;
 
 namespace WindowsEdgeLight;
 
@@ -84,6 +85,25 @@ public partial class ControlWindow : Window
         settings.Owner = this;
         settings.ShowDialog();
         ApplyButtonVisibility();
+    }
+
+    private void DragHandle_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.LeftButton != MouseButtonState.Pressed)
+        {
+            return;
+        }
+
+        mainWindow.NotifyControlWindowManuallyMoved();
+
+        try
+        {
+            DragMove();
+        }
+        catch (System.InvalidOperationException)
+        {
+            // DragMove can throw if the mouse button is no longer pressed; ignore.
+        }
     }
 
     private void Close_Click(object sender, RoutedEventArgs e)

--- a/WindowsEdgeLight/MainWindow.xaml.cs
+++ b/WindowsEdgeLight/MainWindow.xaml.cs
@@ -36,6 +36,8 @@ public partial class MainWindow : Window
     private ControlWindow? controlWindow;
     // Tracks whether the control window should be visible (controls initial visibility and toggle state)
     private bool isControlWindowVisible = true;
+    // Session-only: once the user drags the control toolbar, stop auto-repositioning it.
+    private bool controlWindowManuallyMoved = false;
     private ToolStripMenuItem? toggleControlsMenuItem;
     private ToolStripMenuItem? excludeFromCaptureMenuItem;
     
@@ -1258,9 +1260,23 @@ Version {version}";
     {
         if (controlWindow == null) return;
 
+        // Respect a user-dragged position for the current session.
+        if (controlWindowManuallyMoved) return;
+
         // Position at bottom center of main window
         controlWindow.Left = this.Left + (this.Width - controlWindow.Width) / 2;
         controlWindow.Top = this.Top + this.Height - controlWindow.Height - 124;
+    }
+
+    public void NotifyControlWindowManuallyMoved()
+    {
+        controlWindowManuallyMoved = true;
+    }
+
+    public void ResetControlWindowPosition()
+    {
+        controlWindowManuallyMoved = false;
+        RepositionControlWindow();
     }
 
     public bool HasMultipleMonitors()

--- a/WindowsEdgeLight/SettingsWindow.xaml
+++ b/WindowsEdgeLight/SettingsWindow.xaml
@@ -206,6 +206,37 @@
                             Click="ShowMonitorControls_Click" />
                     </StackPanel>
                 </Border>
+
+                <!-- Control Bar Position -->
+                <Border
+                    Margin="0,0,0,12"
+                    Padding="16"
+                    Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock FontWeight="SemiBold" Text="📍 Control Bar Position" />
+                            <TextBlock
+                                Margin="0,4,0,0"
+                                FontSize="12"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                TextWrapping="Wrap"
+                                Text="Reset the control bar location back to its default." />
+                        </StackPanel>
+                        <Button
+                            Grid.Column="1"
+                            Margin="12,0,0,0"
+                            VerticalAlignment="Center"
+                            Content="Reset Position"
+                            Click="ResetControlBarPosition_Click" />
+                    </Grid>
+                </Border>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/WindowsEdgeLight/SettingsWindow.xaml.cs
+++ b/WindowsEdgeLight/SettingsWindow.xaml.cs
@@ -133,6 +133,11 @@ public partial class SettingsWindow : Window
         UpdateOwnerControlWindow();
     }
 
+    private void ResetControlBarPosition_Click(object sender, RoutedEventArgs e)
+    {
+        mainWindow.ResetControlWindowPosition();
+    }
+
     private void UpdateOwnerControlWindow()
     {
         if (Owner is ControlWindow controlWindow)


### PR DESCRIPTION
## Add Drag support for Control Window

Dragging the control window stops any automatic positioning of the window for that session, but it resets when closed and re-opened. Adds a button in the settings window to reset the location to centered on the main window.

## Changes

- Add Drag handle in the Control Window. Grabbing this drag handle moves the entire control window.
- Add reset button in the Settings Window to reset the Control Window location.

## Screenshots

<img width="323" height="49" alt="image" src="https://github.com/user-attachments/assets/38d93082-af31-4e92-9876-21200d13162c" />
